### PR TITLE
feat: initial-capability

### DIFF
--- a/.github/cspell.yaml
+++ b/.github/cspell.yaml
@@ -1,0 +1,31 @@
+---
+# cSpell Settings
+
+version: "0.2"
+
+# flagWords - list of words to be always considered incorrect
+# This is useful for offensive words and common spelling errors.
+# For example "hte" should be "the"
+flagWords:
+  - hte
+
+language: en
+
+# words - list of words to be always considered correct: an Allowlist per-se
+words:
+  # bazel words
+  - Stardoc
+  - bazel
+  - bazelisk
+  - bazelrc
+  - bazelspk
+  - buildifier
+  - bzlmod
+  - bzlmodify
+  - ibazel
+  - rulesets
+  # Vanity
+  - allanc
+  - chickenandpork
+  # Actual useful words
+  - multiarch

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        ".github/workflows/.*.yml"
+      ],
+      "matchStrings": [
+        "renovatebot datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION: (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}"
+    }
+  ],
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "enabled": true,
+      "matchManagers": [
+        "bazel",
+        "bazel-module"
+      ]
+    },
+    {
+      "automerge": true,
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,35 @@
+name: automerge
+
+# https://github.com/ridedott/merge-me-action/discussions/997#discussioncomment-3166077
+# yamllint disable-line rule:truthy
+on:
+  check_suite:
+    conclusion: success
+    # status: {}  # check_events only listenable in main/master branch in github app
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+    # permissions: write-all
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+      ## actions: read|write|none
+      # checks: write
+      # contents: write
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "!wip"
+          MERGE_METHOD_LABELS: "automerge=merge,autosquash=squash"
+          MERGE_METHOD_LABEL_REQUIRED: true
+          MERGE_COMMIT_MESSAGE: "pull-request-description"
+          MERGE_RETRIES: "10"
+          MERGE_RETRY_SLEEP: "30000"
+          MERGE_REQUIRED_APPROVALS: "0"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,43 @@
+---
+name: Build
+env:
+  # Building on mac? Don't ever update homebrew: a huge cycles-consumer even if you ARE using it
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches-ignore:
+      - master  # master handled in release.yaml
+
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]  # macos-latest
+    steps:
+      -
+        name: Date-Based Cache key
+        # get a key showing the current week (ISO: yyyyWww)
+        id: week
+        run: echo "::set-output name=iso::$(date +'bazel-%YW%U')"
+      -
+        uses: bazel-contrib/setup-bazel@0.9.0
+        with:
+          # Cache bazel downloads via bazelisk
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ steps.week.outputs.iso }}
+          # Share repository cache between workflows.
+          repository-cache: true
+      -
+        uses: actions/checkout@v4
+        # action runners have bazelisk: - uses: bazelbuild/setup-bazelisk@v2
+        # https://github.com/bazelbuild/bazel/issues/11062
+      #-
+      #  run: bazel test //... --test_output=errors --test_summary=detailed
+      -
+        run: bazel shutdown

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+MODULE.bazel.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+# To install the dependencies for this file:
+# 1) pip install pre-commit
+#   (really, "sudo python3 -m pip install pre-commit")
+#   (really, I've been carrying this boilerplate for years, but now it's all python3?)
+#
+# 2) pre-commit install --allow-missing-config
+#
+# yamllint checks this .pre-commit-config file as well
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.33.0
+    hooks:
+      - id: yamllint
+        args: [
+          '-d',
+          '{extends: relaxed, rules: {line-length: {max: 120}}}'
+        ]
+        files: .*\.(yml|yaml)$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.3
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.3.0
+    hooks:
+      - id: cspell
+        # a local allowlist of dictionary words in .github/cspell.yaml.  This can get comical --
+        # adding new words in every PR -- but the cost/benefit balance may avoid some embarassing
+        # typos
+        args: ['--config', '.github/cspell.yaml']
+        types: [file, markdown]
+
+  - repo: local
+    hooks:
+      - id: buildifier
+        # name: bazel run @buildifier_prebuilt//:buildifier -- -config .github/buildifier.json
+        description: Cleans up BUILD files as confirmed in starlark linter
+        entry: bash -c 'cd $(pwd) && bazel run @buildifier_prebuilt//:buildifier'
+        files: '\.bazel$|\.bzl$'
+        language: system
+        name: bazel run @buildifier_prebuilt//:buildifier

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,48 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("multi_arch.bzl", "multi_arch")
+
+cc_binary(
+    name = "a",
+    srcs = ["hello.cc"],
+)
+cc_binary(
+    name = "b",
+    srcs = ["hello.cc"],
+)
+
+multi_arch(
+    name = "a.arm",
+    image = ":a",
+    platforms = [":arm"],
+)
+multi_arch(
+    name = "b.x86",
+    image = ":b",
+    platforms = [":x86"],
+)
+
+platform(
+    name = "x86",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ]
+)
+platform(
+    name = "arm",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ]
+)
+
+# rules_pkg has forked and extended packaging rules
+pkg_tar(
+    name = "tar-t",
+    srcs = [
+        ":a.arm",
+        ":b.x86",
+    ],
+)
+
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,24 @@
+module(
+    name = "bazel-example-multiarch-transitions",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "aspect_bazel_lib", version = "2.9.1")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "gazelle", version = "0.39.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_cc", version = "0.0.13")
+bazel_dep(name = "rules_go", version = "0.50.1")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_shellcheck", version = "0.3.3", repo_name = "com_github_aignas_rules_shellcheck")
+bazel_dep(name = "stardoc", version = "0.7.1")
+
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
+
+
+toolchains = use_extension("//toolchains:extensions.bzl", "toolchains")
+use_repo(toolchains, "arm64_gcc_linux_x86_64")
+
+# register toolchains by wildcard :) (thanks, github/cameron-martin)
+register_toolchains("//toolchains:all")
+

--- a/hello.cc
+++ b/hello.cc
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main() {
+   printf("\n\nHello, World!\n\n");
+
+   return 0;
+}
+

--- a/multi_arch.bzl
+++ b/multi_arch.bzl
@@ -1,0 +1,25 @@
+def _multi_arch_transition_impl(settings, attr):
+    return [
+        {"//command_line_option:platforms": str(platform)}
+        for platform in attr.platforms
+    ]
+
+multi_arch_transition = transition(
+    implementation = _multi_arch_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _multi_arch_impl(ctx):
+    return DefaultInfo(files = depset(ctx.files.image))
+
+multi_arch = rule(
+    implementation = _multi_arch_impl,
+    attrs = {
+        "image": attr.label(cfg=multi_arch_transition),
+        "platforms": attr.label_list(),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        )
+    }
+)

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -1,0 +1,21 @@
+toolchain(
+    name = "arm64_gcc_linux_x86_64",
+    # registered in //toolchains:deps.bzl imported by //:deps.bzl
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = "@arm64_gcc_linux_x86_64//:cc_toolchain",
+    toolchain_type = "@rules_cc//cc:toolchain_type",
+)
+
+platform(
+    name = "toolchain_arm64_gcc",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+    ],
+)
+

--- a/toolchains/arm64_gcc_linux_x86_64.BUILD
+++ b/toolchains/arm64_gcc_linux_x86_64.BUILD
@@ -1,0 +1,64 @@
+# this referenced from the `maybe(.., name="arm64_gcc_linux_x86_64", ..)` allows the binaries to be accessible from the Bazel target @arm64_gcc_linux_x86_64//:all
+#
+# This is ultimately called via:
+#
+# # get the toolchains
+# load("@rules_synology//:deps.bzl", synology_deps="deps")
+# synology_deps()
+#
+# bazel build :main --platforms=@rules_synology//toolchains:toolchain_arm64_gcc --incompatible_enable_cc_toolchain_resolution
+
+filegroup(
+    name = "all",
+    srcs = glob(["**/*",]),
+)
+
+# this allows the cc_toolchain to be accessible from the Bazel target @arm64_gcc_linux_x86_64//:cc_toolchain
+cc_toolchain(
+    name = "cc_toolchain",
+    all_files = ":all",
+    ar_files = ":all",
+    as_files = ":all",
+    compiler_files = ":all",
+    dwp_files = ":all",
+    linker_files = ":all",
+    objcopy_files = ":all",
+    strip_files = ":all",
+    static_runtime_lib = ":all",
+    toolchain_config = ":_cc_toolchain_config",
+)
+
+load("@bazel_tools//tools/cpp:unix_cc_toolchain_config.bzl", "cc_toolchain_config")
+
+cc_toolchain_config(
+    name = "_cc_toolchain_config",
+    cpu = "arm64",
+    compiler = "gcc",
+    toolchain_identifier = "arm64_gcc",
+    host_system_name = "local",
+    target_system_name = "local",
+    target_libc = "unknown",
+    abi_version = "unknown",
+    abi_libc_version = "unknown",
+    tool_paths = {
+        "gcc": "bin/aarch64-none-linux-gnu-gcc",
+        "cpp": "bin/aarch64-none-linux-gnu-cpp",
+        "ar": "bin/aarch64-none-linux-gnu-ar",
+        "nm": "bin/aarch64-none-linux-gnu-nm",
+        "ld": "bin/aarch64-none-linux-gnu-ld",
+        "as": "bin/aarch64-none-linux-gnu-as",
+        "objcopy": "bin/aarch64-none-linux-gnu-objcopy",
+        "objdump": "bin/aarch64-none-linux-gnu-objdump",
+        "gcov": "bin/aarch64-none-linux-gnu-gcov",
+        "strip": "bin/aarch64-none-linux-gnu-strip",
+        "llvm-cov": "/bin/false",
+    },
+    compile_flags = [
+        "-isystem", "external/_main~toolchains~arm64_gcc_linux_x86_64/aarch64-none-linux-gnu/include/c++/12.2.1/aarch64-none-linux-gnu",
+        "-isystem", "external/_main~toolchains~arm64_gcc_linux_x86_64/aarch64-none-linux-gnu/include/c++/12.2.1",
+        "-isystem", "external/_main~toolchains~arm64_gcc_linux_x86_64/aarch64-none-linux-gnu/include",
+        "-isystem", "external/_main~toolchains~arm64_gcc_linux_x86_64/aarch64-none-linux-gnu/libc/usr/include",
+        "-isystem", "external/_main~toolchains~arm64_gcc_linux_x86_64/lib/gcc/aarch64-none-linux-gnu/12.2.1/include",
+    ],
+    link_flags = [],
+)

--- a/toolchains/extensions.bzl
+++ b/toolchains/extensions.bzl
@@ -1,0 +1,18 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def _impl(_):
+    maybe(
+        repo_rule = http_archive,
+        name = "arm64_gcc_linux_x86_64",
+        urls = ["https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz"],
+        strip_prefix = "arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-linux-gnu",
+        sha256 = "6e8112dce0d4334d93bd3193815f16abe6a2dd5e7872697987a0b12308f876a4",
+        build_file = "//toolchains:arm64_gcc_linux_x86_64.BUILD",
+    )
+
+
+toolchains = module_extension(
+    implementation = _impl,
+)
+

--- a/tools/dockerbuild
+++ b/tools/dockerbuild
@@ -1,0 +1,32 @@
+set -x
+
+TEST_TMPDIR=$(mktemp -d)
+trap cleanup 1 2 3 6 15
+cleanup() {
+    test -s "${TEST_TMPDIR}" && rm -fr "${TEST_TMPDIR}"
+    exit 1
+}
+
+WORKSPACE="$(bash cd $(dirname $(dirname $0)) && pwd)"
+
+
+while getopts "a:t::" opt; do
+  case ${opt} in
+    a)
+      ACTION="${OPTARG}"
+      ;;
+    t)
+      TARGETS="${TARGETS} ${OPTARG}"
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}."
+      exit 1
+      ;;
+  esac
+done
+
+docker run -e USER="$(id -u)" -u="$(id -u)" -e USE_BAZEL_VERSION="${USE_BAZEL_VERSION:-7.4.0}" \
+  -v ${TEST_TMPDIR}:/tmp -e TEST_TMPDIR=/tmp \
+  -v "${WORKSPACE}:/src/workspace" -w /src/workspace \
+  gcr.io/bazel-public/bazel:latest \
+  --output_user_root=/tmp/build_output ${ACTION:-build} ${TARGETS:-//...}


### PR DESCRIPTION
This is the initial proof of cross-compile capability as part of a multi-arch for a list of architectures (in the example, 2).

Originally written by Kevin Wang, this basic cross-compile example produced exceptions such as `failed: absolute path inclusion(s) found in rule` when building.

The code is then altered for the new name spacing on dependent repositories and the error doesn't recur.