### PR TITLE
chore: trim direct dependencies, uneclipse transient deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,14 +4,6 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.9.3")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "gazelle", version = "0.39.1")
-bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_cc", version = "0.0.13")
-bazel_dep(name = "rules_go", version = "0.50.1")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_shellcheck", version = "0.3.3", repo_name = "com_github_aignas_rules_shellcheck")
-bazel_dep(name = "stardoc", version = "0.7.1")
 
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 


### PR DESCRIPTION
Full disclosure: my MODULE.bazel was copied.  Yep, copy-pasta nightmares.  soooo sticky..

Stating direct dependencies in `MODULE.bazel` can eclipse those declared by actual dependencies, and I'd churn when updated (renovateBot updating things we don't care about give us activity that doesn't yield change nor benefit)

... so let's trim them.    FOR GREAT JUSTICE!  And cake.